### PR TITLE
AFS Quota checking functionality for drupal user messages.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Stanford Sites Helper x.x-x.x, xxxx-xx-xx
 -----------------------------------------
 
+Stanford Sites Helper 7.x-1.0-beta9, xxxx-xx-xx
+-----------------------------------------
+- Added AFS storage quota warning message and email functionality for sites that run on the AFS file storage.
+
 Stanford Sites Helper 7.x-1.0-beta8, 2013-09-06
 -----------------------------------------------
 -Minor CSS tweaks for welcome text
@@ -22,7 +26,7 @@ By jbickar: added link to HelpSU on password request form
 
 Stanford Sites Helper 7.x-1.0-beta3, 2012-09-14
 -----------------------------------------------
-By meganem: Added plus icons to collapsible fieldsets 
+By meganem: Added plus icons to collapsible fieldsets
 
 Stanford Sites Helper 7.x-1.0-beta2, 2012-09-10
 -----------------------------------------------

--- a/stanford_sites_helper.install
+++ b/stanford_sites_helper.install
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @file
+ * Stanford Sites Installation File. Contains installation hooks.
+ */
+
+/**
+ * implements hook_requirements
+ */
+
+function stanford_sites_helper_requirements($phase) {
+  $requirements = array();
+
+  switch ($phase) {
+    case 'runtime':
+
+      $usage = _stanford_sites_helper_get_usage();
+      $last_check = date('Y-m-d g:ia', variable_get('stanford_sites_helper_afsquota_ts', 0));
+      $type = _stanford_sites_helper_get_quota_bool() ? REQUIREMENT_WARNING : REQUIREMENT_INFO;
+
+      $requirements['afsquotastorage'] = array(
+        'title' => 'AFS Storage Limit',
+        'value' => t('As of ' . $last_check . ' your account is using ' . $usage . '% of your total file storage. ') . l('Check again.', 'admin/config/stanford-sites-helper/afsquota/check') . t(' Or, ') . l('request more storage.' , 'http://helpsu.stanford.edu/?pcat=sites'),
+        'severity' => $type,
+      );
+
+      break;
+  }
+  return $requirements;
+}
+/**
+ * [stanford_sites_helper_install description]
+ * @return [type] [description]
+ */
+function stanford_sites_helper_install() {
+
+  // Variable to store wether threshold has been reached.
+  variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+  // Variable to store which roles can see the warning message.
+  variable_set('stanford_sites_helper_afsquota_roles', array(
+    'administrator'
+  ));
+  // Last time limit was checked.
+  variable_set('stanford_sites_helper_afsquota_ts', 0);
+  // Keep track of what the user is at.
+  variable_set('stanford_sites_helper_afsquota_current', 0);
+
+}
+/**
+ * [stanford_sites_helper_uninstall description]
+ * @return [type] [description]
+ */
+function stanford_sites_helper_uninstall() {
+
+  // Remove the vars...
+  variable_del('stanford_sites_helper_afsquota_threshold_bool');
+  variable_del('stanford_sites_helper_afsquota_roles');
+  variable_del('stanford_sites_helper_afsquota_ts');
+  variable_del('stanford_sites_helper_afsquota_current');
+
+}
+
+
+?>

--- a/stanford_sites_helper.install
+++ b/stanford_sites_helper.install
@@ -44,6 +44,8 @@ function stanford_sites_helper_install() {
   variable_set('stanford_sites_helper_afsquota_ts', 0);
   // Keep track of what the user is at.
   variable_set('stanford_sites_helper_afsquota_current', 0);
+  // Have we sent warning email already checker.
+  variable_del('stanford_sites_helper_afsquota_sent_email', 0);
 
 }
 /**
@@ -57,6 +59,7 @@ function stanford_sites_helper_uninstall() {
   variable_del('stanford_sites_helper_afsquota_roles');
   variable_del('stanford_sites_helper_afsquota_ts');
   variable_del('stanford_sites_helper_afsquota_current');
+  variable_del('stanford_sites_helper_afsquota_sent_email');
 
 }
 

--- a/stanford_sites_helper.install
+++ b/stanford_sites_helper.install
@@ -5,7 +5,9 @@
  */
 
 /**
- * implements hook_requirements
+ * Implements hook_requirements.
+ * Performs a runtime check for file storage usage. Information can be
+ * seen at admin/reports/status/
  */
 
 function stanford_sites_helper_requirements($phase) {
@@ -13,14 +15,14 @@ function stanford_sites_helper_requirements($phase) {
 
   switch ($phase) {
     case 'runtime':
-
+      $t = get_t();
       $usage = _stanford_sites_helper_get_usage();
       $last_check = date('Y-m-d g:ia', variable_get('stanford_sites_helper_afsquota_ts', 0));
       $type = _stanford_sites_helper_get_quota_bool() ? REQUIREMENT_WARNING : REQUIREMENT_INFO;
 
       $requirements['afsquotastorage'] = array(
-        'title' => 'AFS Storage Limit',
-        'value' => t('As of ' . $last_check . ' your account is using ' . $usage . '% of your total file storage. ') . l('Check again.', 'admin/config/stanford-sites-helper/afsquota/check') . t(' Or, ') . l('request more storage.' , 'http://helpsu.stanford.edu/?pcat=sites'),
+        'title' => 'File Storage Limit',
+        'value' => $t('As of ' . $last_check . ' your account is using ' . $usage . '% of your total file storage. ') . l('Check again.', 'admin/config/stanford-sites-helper/filequota/check') . $t(' Or, ') . l('request more storage.' , 'http://helpsu.stanford.edu/?pcat=sites'),
         'severity' => $type,
       );
 
@@ -29,12 +31,12 @@ function stanford_sites_helper_requirements($phase) {
   return $requirements;
 }
 /**
- * [stanford_sites_helper_install description]
- * @return [type] [description]
+ * Implements hook_install
+ * Sets default variables for use in system.
  */
 function stanford_sites_helper_install() {
 
-  // Variable to store wether threshold has been reached.
+  // Variable to store whether threshold has been reached.
   variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
   // Variable to store which roles can see the warning message.
   variable_set('stanford_sites_helper_afsquota_roles', array(
@@ -49,8 +51,8 @@ function stanford_sites_helper_install() {
 
 }
 /**
- * [stanford_sites_helper_uninstall description]
- * @return [type] [description]
+ * Implements hook_uninstall
+ * Removes variables from DB.
  */
 function stanford_sites_helper_uninstall() {
 

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -293,7 +293,7 @@ function stanford_sites_helper_page_check_quota() {
     $output .= "<h3 class=\"warning\">" . t('You are nearing your file storage limit. Please submit a ') . l('HelpSU request' , 'http://helpsu.stanford.edu/?pcat=sites') . t(' for more storage.') . "</h3>";
   }
   else {
-    $output .= "<h3>" . t('No problems here!') . "</h3><p>" . t('You are well under your file storage limit. please carry on your site tasks as normal. For more information please see the ') . l('site status report page.', 'admin/reports/status') . "</p>";
+    $output .= "<h3>" . t('No problems here!') . "</h3><p>" . t('You are well under your file storage limit. Please carry on your site tasks as normal. For more information please see the ') . l('site status report page.', 'admin/reports/status') . "</p>";
   }
 
   return $output;
@@ -432,7 +432,7 @@ function _stanford_sites_helper_set_quota_warning_message() {
   $usage = _stanford_sites_helper_get_usage();
 
   $message = t('You are currently using ' . $usage . '% of your available storage. Please submit a ') . l('HelpSU' , 'http://helpsu.stanford.edu/?pcat=sites') . t(' request for more storage. If you think this message is incorrect and the issue has been resolved try ') . l('checking again', 'admin/config/stanford-sites-helper/filequota/check') . ".";
-  drupal_set_message($message, 'warning');
+  drupal_set_message($message, 'warning', FALSE);
 
 }
 

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -8,7 +8,7 @@
 // 1 time a day.
 define('SSH_QUOTA_CHECK_LIMIT', 60 * 60 * 24);
 // Whole integer percentage in which to check against.
-define('STANFORD_SUBSITE_HELPER_AFSQUOTA_THRESHOLD', 80);
+define('STANFORD_SUBSITE_HELPER_AFSQUOTA_THRESHOLD', 90);
 /**
  * Implements hook_init().
  */
@@ -246,6 +246,19 @@ function stanford_sites_helper_file_update($file) {
   }
 }
 
+/**
+ * Implements hook_mail
+ */
+function stanford_sites_helper_mail($key, &$message, $params) {
+  switch ($key) {
+    case 'afsquota_warning':
+        $usage = _stanford_sites_helper_get_usage();
+        $message['subject'] = "You are nearing your storage limit on " . $params['site_name'];
+        $message['body'][] = url('<front>', array('absolute' => TRUE)) . " is nearing the AFS storage limit. Currently, " . $usage . "% of your current allocated storage is being used. Please submit a file storage increase request to HelpSU or your website may experience issues and possible downtime. To request a storage increase please use the HelpSU request form found at: http://helpsu.stanford.edu/?pcat=sites. \n\nThank you,\nAFS Storage Warning";
+      break;
+  }
+}
+
 
 // -----------------------------------------------------------------------------
 // AFS QUOTA CHECK HELPERS -----------------------------------------------------
@@ -294,10 +307,18 @@ function _stanford_sites_helper_check_quota() {
     $usage = _stanford_sites_helper_get_usage();
     if($usage >= STANFORD_SUBSITE_HELPER_AFSQUOTA_THRESHOLD) {
       variable_set('stanford_sites_helper_afsquota_threshold_bool', 1);
+
+      $have_i_sent_email = variable_get('stanford_sites_helper_afsquota_sent_email', 0);
+      if($have_i_sent_email == 0) {
+        _stanford_sites_helper_send_warning_email();
+        variable_set('stanford_sites_helper_afsquota_sent_email', 1);
+      }
       return TRUE;
     }
     else {
+      // Quota is back to being ok. Reset warning bool and email notification.
       variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+      variable_set('stanford_sites_helper_afsquota_sent_email', 0);
       return FALSE;
     }
   }
@@ -331,15 +352,18 @@ function _stanford_sites_helper_get_usage_info() {
   );
 
   $results = preg_split('/[\r\n]+/', $raw, -1, PREG_SPLIT_NO_EMPTY);
-  $data = split(' +', trim($results[1]));
+  $data = preg_split('/ +/', trim($results[1]));
 
-  if(!is_array($data) || count($data) !== 5) {
+  if(!is_array($data) || count($data) < 5) {
     throw new Exception("Could not get AFS storage data.");
   }
 
-  // remove '%' from data
-  $data[3] = str_replace('%', '', $data[3]);
-  $data[4] = str_replace('%', '', $data[4]);
+  // remove anything but numbers from data
+  $data[3] = preg_replace('/[^0-9]/', '', $data[3]);
+  $data[4] = preg_replace('/[^0-9]/', '', $data[4]);
+
+  // Ensure only 5 pieces of data.
+  $data = array_slice($data, 0, 5);
 
   return array_combine($keys, $data);
 }
@@ -390,6 +414,33 @@ function _stanford_sites_helper_set_quota_warning_message() {
   drupal_set_message($message, 'warning');
 
 }
+
+/**
+ * Sends an email about the status of the AFS storage usage to user 1
+ * or the passed in array of emails.
+ * @param  array  $emails an array of email accounts to send the email to.
+ * @return boolean - True for success
+ */
+function _stanford_sites_helper_send_warning_email($emails = array()) {
+
+  $to = !empty($emails) ? implode(",", $emails) : _stanford_sites_helper_get_user_1_email();
+  $site_name = variable_get('site_name', 'Your Website');
+  $from = $site_name . ' <no-reply@stanford.edu>';
+  $params = array('site_name' => $site_name);
+  $language = language_default();
+
+  return drupal_mail('stanford_sites_helper', 'afsquota_warning', $to, $language, $params, $from);
+}
+
+/**
+ * Returns user 1's email address
+ * @return string - email address
+ */
+function _stanford_sites_helper_get_user_1_email() {
+  $user = user_load(1);
+  return $user->mail;
+}
+
 /**
  * Small helper function to check to see if request was an ajax request.
  * @return boolean [description]

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -233,8 +233,12 @@ function stanford_sites_helper_form_user_pass_alter(&$form, &$form_state, $form_
  * Implements hook_file_insert
  */
 function stanford_sites_helper_file_insert($file) {
+
   // Every time a new file is saved we should run the check quota.
-  if(_stanford_sites_helper_check_quota()) {
+  variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+  variable_set('stanford_sites_helper_afsquota_ts', 0);
+
+  if (_stanford_sites_helper_check_quota()) {
     _stanford_sites_helper_set_quota_warning_message();
   }
 }
@@ -243,8 +247,12 @@ function stanford_sites_helper_file_insert($file) {
  * Implements hook_file_insert
  */
 function stanford_sites_helper_file_update($file) {
+
   // Every time a new file is updated we should run the check quota.
-  if(_stanford_sites_helper_check_quota()) {
+  variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+  variable_set('stanford_sites_helper_afsquota_ts', 0);
+
+  if (_stanford_sites_helper_check_quota()) {
     _stanford_sites_helper_set_quota_warning_message();
   }
 }
@@ -255,9 +263,9 @@ function stanford_sites_helper_file_update($file) {
 function stanford_sites_helper_mail($key, &$message, $params) {
   switch ($key) {
     case 'afsquota_warning':
-        $usage = _stanford_sites_helper_get_usage();
-        $message['subject'] = "You are nearing your storage limit on " . $params['site_name'];
-        $message['body'][] = url('<front>', array('absolute' => TRUE)) . " is nearing the file storage limit. Currently, " . $usage . "% of your allocated storage is being used. Please submit a file storage increase request to HelpSU or your website may experience issues and possible downtime. To request a storage increase please use the HelpSU request form found at: http://helpsu.stanford.edu/?pcat=sites. \n\nThank you,\nStanford Sites Team";
+      $usage = _stanford_sites_helper_get_usage();
+      $message['subject'] = "You are nearing your storage limit on " . $params['site_name'];
+      $message['body'][] = url('<front>', array('absolute' => TRUE)) . " is nearing the file storage limit. Currently, " . $usage . "% of your allocated storage is being used. Please submit a file storage increase request to HelpSU or your website may experience issues and possible downtime. To request a storage increase please use the HelpSU request form found at: http://helpsu.stanford.edu/?pcat=sites. \n\nThank you,\nStanford Sites Team";
       break;
   }
 }

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -5,10 +5,11 @@
  * User interface tweaks and other modifications for the Stanford Sites platform
  */
 
-// 1 time a day.
+// How often system should check file system usage. 1 time a day.
 define('SSH_QUOTA_CHECK_LIMIT', 60 * 60 * 24);
 // Whole integer percentage in which to check against.
 define('STANFORD_SUBSITE_HELPER_AFSQUOTA_THRESHOLD', 90);
+
 /**
  * Implements hook_init().
  */
@@ -100,8 +101,8 @@ function stanford_sites_helper_menu() {
     'access callback' => 'user_access',
     'access arguments' => array('administer site configuration'),
   );
-  $items['admin/config/stanford-sites-helper/afsquota/check'] = array(
-    'title' => 'Check AFS Storage Quota',
+  $items['admin/config/stanford-sites-helper/filequota/check'] = array(
+    'title' => 'Check File Storage Quota',
     'page callback' => 'stanford_sites_helper_page_check_quota',
     'type' => MENU_CALLBACK,
     'access callback' => 'user_access',
@@ -232,6 +233,7 @@ function stanford_sites_helper_form_user_pass_alter(&$form, &$form_state, $form_
  * Implements hook_file_insert
  */
 function stanford_sites_helper_file_insert($file) {
+  // Every time a new file is saved we should run the check quota.
   if(_stanford_sites_helper_check_quota()) {
     _stanford_sites_helper_set_quota_warning_message();
   }
@@ -241,6 +243,7 @@ function stanford_sites_helper_file_insert($file) {
  * Implements hook_file_insert
  */
 function stanford_sites_helper_file_update($file) {
+  // Every time a new file is updated we should run the check quota.
   if(_stanford_sites_helper_check_quota()) {
     _stanford_sites_helper_set_quota_warning_message();
   }
@@ -254,7 +257,7 @@ function stanford_sites_helper_mail($key, &$message, $params) {
     case 'afsquota_warning':
         $usage = _stanford_sites_helper_get_usage();
         $message['subject'] = "You are nearing your storage limit on " . $params['site_name'];
-        $message['body'][] = url('<front>', array('absolute' => TRUE)) . " is nearing the AFS storage limit. Currently, " . $usage . "% of your current allocated storage is being used. Please submit a file storage increase request to HelpSU or your website may experience issues and possible downtime. To request a storage increase please use the HelpSU request form found at: http://helpsu.stanford.edu/?pcat=sites. \n\nThank you,\nAFS Storage Warning";
+        $message['body'][] = url('<front>', array('absolute' => TRUE)) . " is nearing the file storage limit. Currently, " . $usage . "% of your allocated storage is being used. Please submit a file storage increase request to HelpSU or your website may experience issues and possible downtime. To request a storage increase please use the HelpSU request form found at: http://helpsu.stanford.edu/?pcat=sites. \n\nThank you,\nStanford Sites Team";
       break;
   }
 }
@@ -265,9 +268,10 @@ function stanford_sites_helper_mail($key, &$message, $params) {
 // -----------------------------------------------------------------------------
 
 /**
- * url: admin/config/stanford-sites-helper/afsquota/check
+ * url: admin/config/stanford-sites-helper/filequota/check
  * A page to manually check the quota available. Provides additional
  * information and bypasses the limit check.
+ * @return  'string' page markup
  */
 function stanford_sites_helper_page_check_quota() {
   $output = '';
@@ -288,7 +292,7 @@ function stanford_sites_helper_page_check_quota() {
 }
 
 /**
- * [_stanford_sites_helper_get_quota_bool description]
+ * Returns the quota boolean. Quota boolean is a switch for under or over quota.
  * @return [type] [description]
  */
 function _stanford_sites_helper_get_quota_bool() {
@@ -296,8 +300,10 @@ function _stanford_sites_helper_get_quota_bool() {
 }
 
 /**
- * [_stanford_sites_helper_check_quota description]
- * @return [type] [description]
+ * Check quota function performs the file system storage usage check. If the
+ * qouta threshold has been surpassed an email is sent to user 1 and a message
+ * is prompted to administration users.
+ * @return boolean - True for over threshold.
  */
 function _stanford_sites_helper_check_quota() {
 
@@ -333,8 +339,13 @@ function _stanford_sites_helper_check_quota() {
 }
 
 /**
- * Returns the percentage of the storage space used.
- * @return  Integer the whole number percentage
+ * Returns an array of information about file system usage
+ * @return array - An array of information
+ * - volume name
+ * - quota in bits
+ * - used space in bits
+ * - used percentage
+ * - Total disk usage percentage
  */
 function _stanford_sites_helper_get_usage_info() {
   variable_set('stanford_sites_helper_afsquota_ts', time());
@@ -354,8 +365,10 @@ function _stanford_sites_helper_get_usage_info() {
   $results = preg_split('/[\r\n]+/', $raw, -1, PREG_SPLIT_NO_EMPTY);
   $data = preg_split('/ +/', trim($results[1]));
 
+  // If for some reason the above processing does not produce an array of
+  // information we should throw out an exception.
   if(!is_array($data) || count($data) < 5) {
-    throw new Exception("Could not get AFS storage data.");
+    throw new Exception("Could not get file storage data.");
   }
 
   // remove anything but numbers from data
@@ -365,6 +378,7 @@ function _stanford_sites_helper_get_usage_info() {
   // Ensure only 5 pieces of data.
   $data = array_slice($data, 0, 5);
 
+  // Key the data and return to caller.
   return array_combine($keys, $data);
 }
 
@@ -378,7 +392,7 @@ function _stanford_sites_helper_get_usage() {
     $info = _stanford_sites_helper_get_usage_info();
   }
   catch (Exception $e) {
-    watchdog('stanford_sites_helper', 'Error getting AFS Data. Possibly could not execute shell function or shell function does not exist.');
+    watchdog('stanford_sites_helper', 'Error getting file storage data. Possibly could not execute shell function or shell function does not exist.');
     return 0;
   }
 
@@ -389,7 +403,6 @@ function _stanford_sites_helper_get_usage() {
 /**
  * Creates a user message for adminstrators to let them know that their afs
  * storage is nearing its limit.
- * @return [type] [description]
  */
 function _stanford_sites_helper_set_quota_warning_message() {
 
@@ -410,7 +423,7 @@ function _stanford_sites_helper_set_quota_warning_message() {
 
   $usage = _stanford_sites_helper_get_usage();
 
-  $message = t('You are currently using ' . $usage . '% of your available storage. Please submit a ') . l('HelpSU' , 'http://helpsu.stanford.edu/?pcat=sites') . t(' request for more storage. If you think this message is incorrect and the issue has been resolved try ') . l('checking again', 'admin/config/stanford-sites-helper/afsquota/check') . ".";
+  $message = t('You are currently using ' . $usage . '% of your available storage. Please submit a ') . l('HelpSU' , 'http://helpsu.stanford.edu/?pcat=sites') . t(' request for more storage. If you think this message is incorrect and the issue has been resolved try ') . l('checking again', 'admin/config/stanford-sites-helper/filequota/check') . ".";
   drupal_set_message($message, 'warning');
 
 }

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -230,7 +230,7 @@ function stanford_sites_helper_form_user_pass_alter(&$form, &$form_state, $form_
 }
 
 /**
- * Implements hook_file_insert
+ * Implements hook_file_insert().
  */
 function stanford_sites_helper_file_insert($file) {
 
@@ -244,7 +244,7 @@ function stanford_sites_helper_file_insert($file) {
 }
 
 /**
- * Implements hook_file_insert
+ * Implements hook_file_update().
  */
 function stanford_sites_helper_file_update($file) {
 
@@ -257,6 +257,14 @@ function stanford_sites_helper_file_update($file) {
   }
 }
 
+/**
+ * Implements hook_file_delete().
+ */
+function stanford_sites_helper_file_delete($file) {
+  // Every time a file is deleted we should reset the clock.
+  variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+  variable_set('stanford_sites_helper_afsquota_ts', 0);
+}
 /**
  * Implements hook_mail
  */

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -333,6 +333,10 @@ function _stanford_sites_helper_get_usage_info() {
   $results = preg_split('/[\r\n]+/', $raw, -1, PREG_SPLIT_NO_EMPTY);
   $data = split(' +', trim($results[1]));
 
+  if(!is_array($data) || count($data) !== 5) {
+    throw new Exception("Could not get AFS storage data.");
+  }
+
   // remove '%' from data
   $data[3] = str_replace('%', '', $data[3]);
   $data[4] = str_replace('%', '', $data[4]);
@@ -345,7 +349,15 @@ function _stanford_sites_helper_get_usage_info() {
  * @return integer
  */
 function _stanford_sites_helper_get_usage() {
-  $info = _stanford_sites_helper_get_usage_info();
+
+  try{
+    $info = _stanford_sites_helper_get_usage_info();
+  }
+  catch (Exception $e) {
+    watchdog('stanford_sites_helper', 'Error getting AFS Data. Possibly could not execute shell function or shell function does not exist.');
+    return 0;
+  }
+
   variable_set('stanford_sites_helper_afsquota_current', $info['percentage_used']);
   return $info['percentage_used'];
 }

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -5,12 +5,24 @@
  * User interface tweaks and other modifications for the Stanford Sites platform
  */
 
+// 1 time a day.
+define('SSH_QUOTA_CHECK_LIMIT', 60 * 60 * 24);
+// Whole integer percentage in which to check against.
+define('STANFORD_SUBSITE_HELPER_AFSQUOTA_THRESHOLD', 80);
 /**
  * Implements hook_init().
  */
 function stanford_sites_helper_init() {
   $path = drupal_get_path('module', 'stanford_sites_helper') . '/css/stanford-sites-helper.css';
+
+  // Check to see if the quota is passed the threshold.
+  // If it is then prompt the user with a message.
+  if(!_is_ajax_request() && user_is_logged_in() && _stanford_sites_helper_check_quota()) {
+    _stanford_sites_helper_set_quota_warning_message();
+  }
+
 }
+
 
 /**
  * Implements hook_theme_registry_alter().
@@ -88,6 +100,13 @@ function stanford_sites_helper_menu() {
     'access callback' => 'user_access',
     'access arguments' => array('administer site configuration'),
   );
+  $items['admin/config/stanford-sites-helper/afsquota/check'] = array(
+    'title' => 'Check AFS Storage Quota',
+    'page callback' => 'stanford_sites_helper_page_check_quota',
+    'type' => MENU_CALLBACK,
+    'access callback' => 'user_access',
+    'access arguments' => array('administer site configuration'),
+  );
   return $items;
 }
 
@@ -107,7 +126,7 @@ function stanford_sites_helper_theme($existing, $type, $theme, $path) {
 function stanford_sites_helper_backup_migrate_profiles() {
   //set this profile as default
   variable_set('backup_migrate_profile_id', 'stanford_sites_default');
-  
+
   $out = array();
 
   // Get the stanford_sites_default profile.
@@ -117,7 +136,7 @@ function stanford_sites_helper_backup_migrate_profiles() {
     'filename' => '[site:name]',
     'append_timestamp' => '1',
     'timestamp_format' => 'Y-m-d\\TH-i-s',
-    'filters' => 
+    'filters' =>
     array(
       'compression' => 'gzip',
       'notify_success_enable' => 0,
@@ -127,14 +146,14 @@ function stanford_sites_helper_backup_migrate_profiles() {
       'utils_site_offline' => 0,
       'utils_site_offline_message' => 'This site is currently under maintenance. We should be back shortly. Thank you for your patience.',
       'utils_description' => '',
-      'destinations' => 
+      'destinations' =>
       array(
-        'db' => 
+        'db' =>
         array(
-          'exclude_tables' => 
+          'exclude_tables' =>
           array(
           ),
-          'nodata_tables' => 
+          'nodata_tables' =>
           array(
             'cache' => 'cache',
             'cache_admin_menu' => 'cache_admin_menu',
@@ -159,7 +178,7 @@ function stanford_sites_helper_backup_migrate_profiles() {
           'utils_lock_tables' => 0,
           'use_mysqldump' => 0,
         ),
-        'files' => 
+        'files' =>
         array(
           'exclude_filepaths' => 'backup_migrate
   styles
@@ -170,7 +189,7 @@ function stanford_sites_helper_backup_migrate_profiles() {
   tmp
   private',
         ),
-        'files_private' => 
+        'files_private' =>
         array(
           'exclude_filepaths' => 'backup_migrate
   styles
@@ -208,3 +227,162 @@ function stanford_sites_helper_form_user_pass_alter(&$form, &$form_state, $form_
   $message = t('If you are having difficulty resetting your password, please !submithelpsu.', array('!submithelpsu' => l('submit a HelpSU request', 'https://helpsu.stanford.edu/?pcat=sites')));
   $form['name']['#suffix'] = $message;
 }
+
+/**
+ * Implements hook_file_insert
+ */
+function stanford_sites_helper_file_insert($file) {
+  if(_stanford_sites_helper_check_quota()) {
+    _stanford_sites_helper_set_quota_warning_message();
+  }
+}
+
+/**
+ * Implements hook_file_insert
+ */
+function stanford_sites_helper_file_update($file) {
+  if(_stanford_sites_helper_check_quota()) {
+    _stanford_sites_helper_set_quota_warning_message();
+  }
+}
+
+
+// -----------------------------------------------------------------------------
+// AFS QUOTA CHECK HELPERS -----------------------------------------------------
+// -----------------------------------------------------------------------------
+
+/**
+ * url: admin/config/stanford-sites-helper/afsquota/check
+ * A page to manually check the quota available. Provides additional
+ * information and bypasses the limit check.
+ */
+function stanford_sites_helper_page_check_quota() {
+  $output = '';
+
+  variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+  variable_set('stanford_sites_helper_afsquota_ts', 0);
+
+  $check = _stanford_sites_helper_check_quota();
+
+  if($check){
+    $output .= "<h3 class=\"warning\">" . t('You are nearing your file storage limit. Please submit a ') . l('HelpSU request' , 'http://helpsu.stanford.edu/?pcat=sites') . t(' for more storage.') . "</h3>";
+  }
+  else {
+    $output .= "<h3>" . t('No problems here!') . "</h3><p>" . t('You are well under your file storage limit. please carry on your site tasks as normal. For more information please see the ') . l('site status report page.', 'admin/reports/status') . "</p>";
+  }
+
+  return $output;
+}
+
+/**
+ * [_stanford_sites_helper_get_quota_bool description]
+ * @return [type] [description]
+ */
+function _stanford_sites_helper_get_quota_bool() {
+  return variable_get('stanford_sites_helper_afsquota_threshold_bool', 0);
+}
+
+/**
+ * [_stanford_sites_helper_check_quota description]
+ * @return [type] [description]
+ */
+function _stanford_sites_helper_check_quota() {
+
+  // Check if we need to check.
+  $last_check = variable_get('stanford_sites_helper_afsquota_ts', 0);
+  if(($last_check + SSH_QUOTA_CHECK_LIMIT) < time()) {
+    $usage = _stanford_sites_helper_get_usage();
+    if($usage >= STANFORD_SUBSITE_HELPER_AFSQUOTA_THRESHOLD) {
+      variable_set('stanford_sites_helper_afsquota_threshold_bool', 1);
+      return TRUE;
+    }
+    else {
+      variable_set('stanford_sites_helper_afsquota_threshold_bool', 0);
+      return FALSE;
+    }
+  }
+
+  // See if the quota message has been tiggered.
+  // If it has then we return.
+  if(_stanford_sites_helper_get_quota_bool()) {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+ * Returns the percentage of the storage space used.
+ * @return  Integer the whole number percentage
+ */
+function _stanford_sites_helper_get_usage_info() {
+  variable_set('stanford_sites_helper_afsquota_ts', time());
+  $raw = shell_exec(escapeshellcmd('fs lq sites/default/files'));
+
+  // Volume Name | Quota | Used | %Used | Partition
+  // list($volume_name, $max_quota, $bytes_used, $percentage_used, $partition_usage) = explode($raw, " ");
+
+  $keys = array(
+    'volume_name',
+    'max_bits_quota',
+    'bits_used',
+    'percentage_used',
+    'partition_usage',
+  );
+
+  $results = preg_split('/[\r\n]+/', $raw, -1, PREG_SPLIT_NO_EMPTY);
+  $data = split(' +', trim($results[1]));
+
+  // remove '%' from data
+  $data[3] = str_replace('%', '', $data[3]);
+  $data[4] = str_replace('%', '', $data[4]);
+
+  return array_combine($keys, $data);
+}
+
+/**
+ * Returns the percentage of disk usage.
+ * @return integer
+ */
+function _stanford_sites_helper_get_usage() {
+  $info = _stanford_sites_helper_get_usage_info();
+  variable_set('stanford_sites_helper_afsquota_current', $info['percentage_used']);
+  return $info['percentage_used'];
+}
+
+/**
+ * Creates a user message for adminstrators to let them know that their afs
+ * storage is nearing its limit.
+ * @return [type] [description]
+ */
+function _stanford_sites_helper_set_quota_warning_message() {
+
+  global $user;
+
+  // Do not add message for non authenticated users.
+  if(!user_is_logged_in()) {
+    return;
+  }
+
+  $accepted_roles = variable_get('stanford_sites_helper_afsquota_roles', array('administrator'));
+  $check = array_intersect($accepted_roles, array_values($user->roles));
+
+  // Do not add message for non admin type users.
+  if(!$check) {
+    return;
+  }
+
+  $usage = _stanford_sites_helper_get_usage();
+
+  $message = t('You are currently using ' . $usage . '% of your available storage. Please submit a ') . l('HelpSU' , 'http://helpsu.stanford.edu/?pcat=sites') . t(' request for more storage. If you think this message is incorrect and the issue has been resolved try ') . l('checking again', 'admin/config/stanford-sites-helper/afsquota/check') . ".";
+  drupal_set_message($message, 'warning');
+
+}
+/**
+ * Small helper function to check to see if request was an ajax request.
+ * @return boolean [description]
+ */
+function _is_ajax_request() {
+  return !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest';
+}
+


### PR DESCRIPTION
- Adds a check to hook_init for once a day checking of the file storage limit
- Adds a report to the system reports page
- Adds a manual check bypass page at admin/config/stanford-sites-helper/afsquota/check
- Adds a check to hook_file_insert
- Adds a check to hook_file_update
- There is no hook to be called on file_unmanaged_save_data or file_unmanaged_copy so anything outside the files table will have to be picked up by the daily check
- Added a warning email to user 1 to prompt them for a storage increase
- Set limit threshold to 90%
