### PR TITLE
Adds permission for bundle copy import

### DIFF
--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -29,9 +29,9 @@ function stanford_sites_helper_init() {
  */
 function stanford_sites_helper_permission() {
   return array(
-    'copy bundles' =>  array(
-      'title' => t('Copy bundles'),
-      'description' => t('Provides the ability to copy bundles using the bundle copy module import form.'),
+    'import bundles' =>  array(
+      'title' => t('Import bundles'),
+      'description' => t('Provides the ability to import bundles using the Bundle Copy module import form.'),
     ),
   );
 }
@@ -130,11 +130,11 @@ function stanford_sites_helper_menu_alter(&$items) {
 
   if (module_exists('bundle_copy')) {
     $items['admin/structure/types/import']['access callback'] = "user_access";
-    $items['admin/structure/types/import']['access arguments'] = array("copy bundles");
+    $items['admin/structure/types/import']['access arguments'] = array("import bundles");
     $items['admin/config/people/accounts/import']['access callback'] = "user_access";
-    $items['admin/config/people/accounts/import']['access arguments'] = array("copy bundles");
+    $items['admin/config/people/accounts/import']['access arguments'] = array("import bundles");
     $items['admin/structure/taxonomy/import']['access callback'] = "user_access";
-    $items['admin/structure/taxonomy/import']['access_arguments'] = array("copy bundles");
+    $items['admin/structure/taxonomy/import']['access_arguments'] = array("import bundles");
   }
 
 }

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -24,6 +24,18 @@ function stanford_sites_helper_init() {
 
 }
 
+/**
+ * Implements hook_permission().
+ */
+function stanford_sites_helper_permission() {
+  return array(
+    'copy bundles' =>  array(
+      'title' => t('Copy bundles'),
+      'description' => t('Provides the ability to copy bundles using the bundle copy module import form.'),
+    ),
+  );
+}
+
 
 /**
  * Implements hook_theme_registry_alter().
@@ -111,6 +123,21 @@ function stanford_sites_helper_menu() {
   return $items;
 }
 
+/**
+ * Implements hook_menu_alter().
+ */
+function stanford_sites_helper_menu_alter(&$items) {
+
+  if (module_exists('bundle_copy')) {
+    $items['admin/structure/types/import']['access callback'] = "user_access";
+    $items['admin/structure/types/import']['access arguments'] = array("copy bundles");
+    $items['admin/config/people/accounts/import']['access callback'] = "user_access";
+    $items['admin/config/people/accounts/import']['access arguments'] = array("copy bundles");
+    $items['admin/structure/taxonomy/import']['access callback'] = "user_access";
+    $items['admin/structure/taxonomy/import']['access_arguments'] = array("copy bundles");
+  }
+
+}
 /**
  * Page callback.
  */


### PR DESCRIPTION
Adds a permission called 'copy bundles' to the import pages instead of the PHP one.
