### PR TITLE
HSDO-819 Added drush command to clean wysiwyg fields

### DIFF
--- a/stanford_sites_helper.drush.inc
+++ b/stanford_sites_helper.drush.inc
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * stanford_sites_helper.drush.inc
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function stanford_sites_helper_drush_command() {
+  $items = array();
+
+  $items['stanford-sites-wysiwyg'] = array(
+    'description' => 'Clean all wysiwyg fields on launch day',
+    'arguments' => array(
+      'shortname' => 'Site shortname. Ex: sites.stanford.edu/foo enter "foo" without quotes.',
+    ),
+    'aliases' => array('ssw'),
+  );
+
+  return $items;
+}
+
+/**
+ * Clean up field data to assist with edit forms when the path is incorrect.
+ *
+ * @param string $shortname
+ *   Sites shortname.
+ */
+function drush_stanford_sites_helper_stanford_sites_wysiwyg($shortname = '') {
+  if (!$shortname) {
+    drush_log(dt('No shortname provided'), 'error');
+    return;
+  }
+
+  $shortname = trim($shortname, '/ ');
+  $field_types = array('text', 'text_long', 'text_with_summary');
+
+  foreach ($field_types as $type) {
+    $fields = field_read_fields(array('type' => $type));
+
+    foreach (array_keys($fields) as $field_name) {
+      $tables = array("field_data_$field_name", "field_revision_$field_name");
+      $patterns = array("\"/$shortname/" => '"/');
+
+      $column = "{$field_name}_value";
+
+      foreach ($patterns as $pattern => $replacement) {
+        foreach ($tables as $table) {
+          db_query("UPDATE $table SET $column = REPLACE($column, '$pattern', '$replacement') WHERE $column LIKE '%$pattern%'")->execute();
+        }
+      }
+    }
+  }
+
+  cache_clear_all('*', 'cache_field', TRUE);
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- After a site has launched, the in line images can be broken. If an image is embeded in a wysiwyg field as `<img src="/mysite/sites/default/files/myfile.png" />` the field will render correctly on the entity view page. But when editing the entity (node, beans, etc) the markup doesn't run through pathologic before allowing the user to edit. This drush command will strip out the `/mysite` portion of the src attribute and help the field edit to render the image as desired.
# Needed By (Date)
- 4/26

# Steps to Test
1. Find a live site that contains an in-line image with the src attribute as described above. (I used http://feminist.stanford.edu/ which has the shortname 'fgs' it has a block on the home page in the bottom left that has an inline image.)
2. clone the site locally or create a development copy of your choosing.
4. run `drush ssw mysite` with "mysite" being the shortname of the site.
5. view the edit page of the entity that has the inline image. The image should display on the edit and on the render page.