### PR TITLE
add an agreement to the form when deleting content with a user

### DIFF
--- a/js/stanford_sites_helper.user_delete_confirm.js
+++ b/js/stanford_sites_helper.user_delete_confirm.js
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * States dont work very well because each radio option is its own thing. The
+ * listener will show the form group but wont hide it appropriately.
+ */
+
+(function ($) {
+  Drupal.behaviors.userDeleteConfirm = {
+    attach: function (context, settings) {
+
+      var $userContent = $('#edit-user-cancel-method .user-content', context);
+      $userContent.hide();
+      if ($('input[value="user_cancel_delete"]', context).is(':checked')) {
+        $userContent.show();
+      }
+
+      $('#edit-user-cancel-method input[type="radio"]', context).change(function () {
+        $userContent.hide();
+        if (this.value == 'user_cancel_delete') {
+          $userContent.show();
+        }
+      });
+    }
+  }
+})(jQuery);

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -332,7 +332,7 @@ function _stanford_sites_helper_add_user_content_info(&$form, &$form_state, $use
   // Build the information and confirmation portion.
   $form['user_cancel_method']['user_content'] = [
     '#type' => 'fieldset',
-    '#title' => t("User' Content"),
+    '#title' => t("User's Content"),
     '#attributes' => ['class' => ['user-content']],
   ];
 
@@ -352,7 +352,7 @@ function _stanford_sites_helper_add_user_content_info(&$form, &$form_state, $use
 
   $form['user_cancel_method']['user_content']['delete_content_agree'] = [
     '#type' => 'checkbox',
-    '#title' => t('I understand this content will be deleted. This action can not be undone'),
+    '#title' => t('I understand this content will be deleted. <strong>This action can not be undone.</strong>'),
   ];
 
   $form['#attached']['js'][] = drupal_get_path('module', 'stanford_sites_helper') . '/js/stanford_sites_helper.user_delete_confirm.js';

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -302,7 +302,7 @@ function stanford_sites_helper_views_bulk_operations_form_alter(&$form, &$form_s
  */
 function stanford_sites_helper_form_user_cancel_confirm_form_alter(&$form, &$form_state, $form_id) {
   $user = $form_state['build_info']['args'][0];
-  _stanford_sites_helper_add_user_content_info($form, $form_state, [$user]);
+  _stanford_sites_helper_add_user_content_info($form, $form_state, [$user->uid]);
   $form['#validate'][] = 'stanford_sites_helper_user_cancel_confirm_validate';
 }
 

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -287,13 +287,39 @@ function stanford_sites_helper_stanford_sites_hosted() {
 }
 
 /**
+ * Implements hook_views_bulk_operations_form_alter().
+ */
+function stanford_sites_helper_views_bulk_operations_form_alter(&$form, &$form_state, $vbo) {
+  if (isset($form['user_cancel_method'])) {
+    $uids = array_filter($form_state['values']['views_bulk_operations']);
+    _stanford_sites_helper_add_user_content_info($form, $form_state, $uids);
+    $form['actions']['submit']['#validate'][] = 'stanford_sites_helper_user_cancel_confirm_validate';
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function stanford_sites_helper_form_user_cancel_confirm_form_alter(&$form, &$form_state, $form_id) {
   $user = $form_state['build_info']['args'][0];
+  _stanford_sites_helper_add_user_content_info($form, $form_state, [$user]);
+  $form['#validate'][] = 'stanford_sites_helper_user_cancel_confirm_validate';
+}
+
+/**
+ * Add content information to user cancel form.
+ *
+ * @param $form
+ *   Complete form.
+ * @param $form_state
+ *   Current form state.
+ * @param array $user_ids
+ *   Array of users to be canceled.
+ */
+function _stanford_sites_helper_add_user_content_info(&$form, &$form_state, $user_ids = []) {
   $content = db_select('node', 'n')
     ->fields('n', ['nid', 'title'])
-    ->condition('uid', $user->uid)
+    ->condition('uid', $user_ids, 'IN')
     ->orderBy('changed', 'DESC')
     ->execute()
     ->fetchAllKeyed();
@@ -306,7 +332,7 @@ function stanford_sites_helper_form_user_cancel_confirm_form_alter(&$form, &$for
   // Build the information and confirmation portion.
   $form['user_cancel_method']['user_content'] = [
     '#type' => 'fieldset',
-    '#title' => t('User\' Content'),
+    '#title' => t("User' Content"),
     '#attributes' => ['class' => ['user-content']],
   ];
 
@@ -329,7 +355,6 @@ function stanford_sites_helper_form_user_cancel_confirm_form_alter(&$form, &$for
     '#title' => t('I understand this content will be deleted. This action can not be undone'),
   ];
 
-  $form['#validate'][] = 'stanford_sites_helper_user_cancel_confirm_validate';
   $form['#attached']['js'][] = drupal_get_path('module', 'stanford_sites_helper') . '/js/stanford_sites_helper.user_delete_confirm.js';
 }
 

--- a/stanford_sites_helper.module
+++ b/stanford_sites_helper.module
@@ -285,3 +285,68 @@ function stanford_sites_helper_stanford_sites_hosted() {
     return FALSE;
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_sites_helper_form_user_cancel_confirm_form_alter(&$form, &$form_state, $form_id) {
+  $user = $form_state['build_info']['args'][0];
+  $content = db_select('node', 'n')
+    ->fields('n', ['nid', 'title'])
+    ->condition('uid', $user->uid)
+    ->orderBy('changed', 'DESC')
+    ->execute()
+    ->fetchAllKeyed();
+
+  // The user doesn't have any content. No need to ask the user to agree.
+  if (empty($content)) {
+    return;
+  }
+
+  // Build the information and confirmation portion.
+  $form['user_cancel_method']['user_content'] = [
+    '#type' => 'fieldset',
+    '#title' => t('User\' Content'),
+    '#attributes' => ['class' => ['user-content']],
+  ];
+
+  $list_items = [
+    '#theme' => 'item_list',
+    '#list_type' => 'ul',
+    '#items' => array_slice($content, 0, 5),
+  ];
+
+  if (count($content) > 5) {
+    $list_items['#items'][] = t('@count more', ['@count' => count($content) - 5]);
+  }
+
+  $form['user_cancel_method']['user_content']['nodes'] = [
+    '#markup' => t('The following content will be deleted: !content', ['!content' => render($list_items)]),
+  ];
+
+  $form['user_cancel_method']['user_content']['delete_content_agree'] = [
+    '#type' => 'checkbox',
+    '#title' => t('I understand this content will be deleted. This action can not be undone'),
+  ];
+
+  $form['#validate'][] = 'stanford_sites_helper_user_cancel_confirm_validate';
+  $form['#attached']['js'][] = drupal_get_path('module', 'stanford_sites_helper') . '/js/stanford_sites_helper.user_delete_confirm.js';
+}
+
+/**
+ * Custom validation on user delete form to agree to delete content.
+ *
+ * @param array $form
+ *   Complete form.
+ * @param array $form_state
+ *   Current form state.
+ */
+function stanford_sites_helper_user_cancel_confirm_validate($form, &$form_state) {
+  if ($form_state['values']['user_cancel_method'] != 'user_cancel_delete') {
+    return;
+  }
+
+  if (!$form_state['values']['delete_content_agree']) {
+    form_set_error('delete_content_agree', t('You must agree that you understand this content will be deleted.'));
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add a checkbox that is required when deleting content with a user.
- adds information about how much content will be deleted.

# Needed By (Date)
- asap. before another issue

# Urgency
- High.

# Steps to Test
1. checkout this branch
1. clear cache
1. find a user that has content on a site
1. go to cancel that user.
1. choose to "Delete the account and its content."
1. verify a new area displays that gives a count of how much content will be deleted and a checkbox
1. leave the checkbox unchecked.
1. attempt to delete the user
1. verify you get an error
1. check the box and submit
1. verify it goes through.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)